### PR TITLE
Compact layout and grouped toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,13 +71,12 @@
             <div>
                 <h3>3.3. Дополнительно</h3>
                 <div class="toggle-field">
-                    <label>Расчёт NPV</label>
+                    <label id="discountRateContainer" style="display:none;">Ставка дисконтирования (%) <input type="number" id="discountRate" name="discountRate"></label>
                     <label class="switch">
                         <input type="checkbox" id="npvEnabled">
                         <span class="slider"></span>
                     </label>
                 </div>
-                <label id="discountRateContainer" style="display:none;">Ставка дисконтирования (%) <input type="number" id="discountRate" name="discountRate"></label>
                 <div class="toggle-field">
                     <label>Расчёт IRR</label>
                     <label class="switch">
@@ -88,9 +87,8 @@
             </div>
 
             <div id="demandMultiplier">
-                <h3>3.4. Повышенный спрос (помесячно)</h3>
                 <div class="toggle-field">
-                    <label>Включить</label>
+                    <h3>3.4. Повышенный спрос (помесячно)</h3>
                     <label class="switch">
                         <input type="checkbox" id="demandEnabled">
                         <span class="slider"></span>

--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,7 @@ body {
 }
 
 section {
-    margin-bottom: 40px;
+    margin-bottom: 20px;
 }
 
 h2 {
@@ -13,13 +13,13 @@ h2 {
 
 label {
     display: block;
-    margin-bottom: 10px;
+    margin-bottom: 6px;
 }
 
 .toggle-field {
     display: flex;
     align-items: center;
-    margin-bottom: 10px;
+    margin-bottom: 6px;
 }
 
 .toggle-field > label:first-child {
@@ -77,7 +77,7 @@ input:checked + .slider:before {
 #profitExpenses .expense-row {
     display: flex;
     gap: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 6px;
 }
 
 #monthlyDemand {


### PR DESCRIPTION
## Summary
- reduce margins for sections and labels for denser layout
- keep NPV switch right next to discount rate input
- move demand multiplier switch beside its heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68600a998ac0832ea9f0aa6d229e1df5